### PR TITLE
use `current_dir()` instead of `$PWD` in `schema_from_filepaths()`

### DIFF
--- a/attr/src/lib.rs
+++ b/attr/src/lib.rs
@@ -101,7 +101,7 @@ impl Intermediate {
 }
 
 pub fn schema_from_filepaths(paths: &[&Path]) -> anyhow::Result<OrmliteSchema> {
-    let cwd = env::var("PWD").unwrap_or_default();
+    let cwd = env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
     let cwd = PathBuf::from(cwd);
     let paths = paths.iter().map(|p| cwd.join(p)).collect::<Vec<_>>();
     let invalid_paths = paths.iter().filter(|p| fs::metadata(p).is_err()).collect::<Vec<_>>();

--- a/attr/src/lib.rs
+++ b/attr/src/lib.rs
@@ -101,7 +101,7 @@ impl Intermediate {
 }
 
 pub fn schema_from_filepaths(paths: &[&Path]) -> anyhow::Result<OrmliteSchema> {
-    let cwd = env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    let cwd = env::current_dir().unwrap_or_default();
     let cwd = PathBuf::from(cwd);
     let paths = paths.iter().map(|p| cwd.join(p)).collect::<Vec<_>>();
     let invalid_paths = paths.iter().filter(|p| fs::metadata(p).is_err()).collect::<Vec<_>>();


### PR DESCRIPTION
When I use rust-analyzer in VS Code on macOS I get this error:

```console
proc-macro derive panicked
message: called `Result::unwrap()` on an `Err` value: WithPath { path: "/./usr/sbin/authserver", err: Io(Custom { kind: PermissionDenied, error: Error { depth: 3, inner: Io { path: Some("/./usr/sbin/authserver"), err: Os { code: 13, kind: PermissionDenied, message: "Permission denied" } } } }) }
```

This occurs because `$PWD` is not set which leads to `ormlite` scanning the entire filesystem in order to generate a schema. IMHO it is reasonable to use `$CARGO_MANIFEST_DIR` instead of `$PWD`