### PR TITLE
feat: add support for additional derive macros

### DIFF
--- a/attr/src/metadata/table.rs
+++ b/attr/src/metadata/table.rs
@@ -103,6 +103,15 @@ pub struct TableAttr {
     ///
     pub insert: Option<LitStr>,
 
+    /// Add extra derives to the insertion structs.
+    /// Example:
+    /// #[ormlite(insert = "InsertUser", extra_derives(Serialize, Deserialize))]
+    /// pub struct User {
+    ///   pub id: i32,
+    /// }
+    ///
+    pub extra_derives: Option<Vec<syn::Ident>>,
+
     /// Only used for derive(Insert)
     /// Example:
     /// #[ormlite(returns = "User")]

--- a/core/src/join.rs
+++ b/core/src/join.rs
@@ -1,10 +1,12 @@
 use crate::model::Model;
 use async_trait::async_trait;
+use serde::Deserialize;
 use serde::{Serialize, Serializer};
 use sqlmo::query::Join as JoinQueryFragment;
 use sqlmo::query::SelectColumn;
 use sqlx::{Database, Decode, Encode, Type};
 use std::ops::{Deref, DerefMut};
+use serde::de::Error;
 
 pub trait JoinMeta {
     type IdType: Clone + Send + Eq + PartialEq + std::hash::Hash;
@@ -224,3 +226,22 @@ impl<T: JoinMeta + Serialize> Serialize for Join<T> {
         }
     }
 }
+
+impl<'de, T> Deserialize<'de> for Join<T>
+    where
+        T: JoinMeta + Deserialize<'de>,
+    {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let data = Option::<T>::deserialize(deserializer)?;
+            
+            let (id_type, join_data) = match data {
+                Some(value) => (T::_id(&value), JoinData::QueryResult(value)),
+                None => return Err(D::Error::custom("Invalid value"))
+            };
+    
+            Ok(Join { id: id_type, data: join_data })
+        }
+    }

--- a/macro/src/codegen/insert_model.rs
+++ b/macro/src/codegen/insert_model.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use ormlite_attr::Ident;
 use ormlite_attr::ModelMeta;
 use proc_macro2::TokenStream;
@@ -16,10 +17,19 @@ pub fn struct_InsertModel(ast: &DeriveInput, attr: &ModelMeta) -> TokenStream {
             pub #id: #ty
         }
     });
-    quote! {
-        #[derive(Debug)]
-        #vis struct #insert_model {
-            #(#struct_fields,)*
+    if let Some(extra_derives) = &attr.extra_derives {
+        quote! {
+            #[derive(Debug, #(#extra_derives,)*)]
+            #vis struct #insert_model {
+                #(#struct_fields,)*
+            }
+        }    
+    } else {
+        quote! {
+            #[derive(Debug)]
+            #vis struct #insert_model {
+                #(#struct_fields,)*
+            }
         }
     }
 }

--- a/ormlite/Cargo.toml
+++ b/ormlite/Cargo.toml
@@ -67,4 +67,5 @@ trybuild = { version = "1.0.99", features = ["diff"] }
 env_logger = "0.11.5"
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 serde = { version = "1.0.210", features = ["derive"] }
+serde_json = { version = "1.0.128" }
 chrono = { version = "0.4.38", features = ["serde"] }


### PR DESCRIPTION
Basically, when I use ormlite with the config to create a new entity for insert, I can't deserialize it.
One case of this is when I try to deserialize from an Extractor in Axum.

<details>
  <summary>Problem</summary>

![image](https://github.com/user-attachments/assets/d8430c72-d877-4f40-913c-40c9cfe7abbb)

</details>


<details>
<summary>With this patch</summary>

![image](https://github.com/user-attachments/assets/cc0dc066-ce73-4214-bac0-01a06fbce3f8)

</details>