### PR TITLE
remove the need to explicitly import JoinMeta

### DIFF
--- a/core/src/join.rs
+++ b/core/src/join.rs
@@ -1,5 +1,4 @@
 use crate::model::Model;
-use async_trait::async_trait;
 use serde::de::Error;
 use serde::Deserialize;
 use serde::{Serialize, Serializer};


### PR DESCRIPTION
It's pretty un-intuitive to need to import JoinMeta in my opinion.

This PR just adds a use statement in the quote! so that people don't have to know that they need to import it.

Thoughts?