### PR TITLE
updated readme to note that in Join<MyModel> you cannot us qualified paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ pub struct Person {
 Join support is alpha stage. Right now, `ormlite` only support many-to-one relations (e.g. Person belongs to Organization). 
 Support for many-to-many and one-to-many is planned. If you use this functionality, please report any bugs you encounter.
 
+Note: At the moment using qualified paths in the join attribute is not supported. This is a known issue and will be fixed in the future.
+For example `#[ormlite(join_column = "organization_id")] pub organization: Join<model::Organization>` will not work.
+Instead, you should use `#[ormlite(join_column = "organization_id")] pub organization: Join<Organization>`, assuming Organization is in scope.
+
 ```rust
 #[derive(Model, Debug)]
 pub struct Person {


### PR DESCRIPTION
`Join<my_module::MyModel>` breaks the `Model` macro with error:

```
error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `Users`
  --> ...
   |
10 | #[derive(Debug, ormlite::Model)]
   |                 ^^^^^^^^^^^^^^ expected one of 8 possible tokens
   |
   = note: this error originates in the derive macro `ormlite::Model`
```

So I updated the readme to make note of that until it's fixed