### PR TITLE
Change references to Error and Result -> ormlite::Error and ormlite::Result

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,7 +1,7 @@
-pub type CoreResult<T, E = CoreError> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
-pub enum CoreError {
+pub enum Error {
     #[error(transparent)]
     SqlxError(#[from] sqlx::Error),
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,7 +1,7 @@
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type CoreResult<T, E = CoreError> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum CoreError {
     #[error(transparent)]
     SqlxError(#[from] sqlx::Error),
 

--- a/core/src/insert.rs
+++ b/core/src/insert.rs
@@ -1,4 +1,4 @@
-use crate::CoreResult;
+use crate::error;
 use futures::future::BoxFuture;
 pub use sqlmo::query::OnConflict;
 use sqlmo::{Cte, Dialect, Insert, Select, SelectColumn, ToSql, Union};
@@ -8,7 +8,7 @@ use sqlmo::{Cte, Dialect, Insert, Select, SelectColumn, ToSql, Union};
 pub struct Insertion<'a, Acquire, Model, DB: sqlx::Database> {
     pub acquire: Acquire,
     pub model: Model,
-    pub closure: Box<dyn 'static + Send + FnOnce(Acquire, Model, String) -> BoxFuture<'a, CoreResult<Model>>>,
+    pub closure: Box<dyn 'static + Send + FnOnce(Acquire, Model, String) -> BoxFuture<'a, error::Result<Model>>>,
     pub insert: Insert,
     pub _db: std::marker::PhantomData<DB>,
 }
@@ -23,7 +23,7 @@ impl<'a, Acquire, Model, DB: sqlx::Database> Insertion<'a, Acquire, Model, DB> {
 impl<'a, Acquire, Model: crate::model::Model<DB>, DB: sqlx::Database> std::future::IntoFuture
     for Insertion<'a, Acquire, Model, DB>
 {
-    type Output = CoreResult<Model>;
+    type Output = error::Result<Model>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {

--- a/core/src/join.rs
+++ b/core/src/join.rs
@@ -1,12 +1,12 @@
 use crate::model::Model;
 use async_trait::async_trait;
+use serde::de::Error;
 use serde::Deserialize;
 use serde::{Serialize, Serializer};
 use sqlmo::query::Join as JoinQueryFragment;
 use sqlmo::query::SelectColumn;
 use sqlx::{Database, Decode, Encode, Type};
 use std::ops::{Deref, DerefMut};
-use serde::de::Error;
 
 pub trait JoinMeta {
     type IdType: Clone + Send + Eq + PartialEq + std::hash::Hash;
@@ -31,7 +31,7 @@ impl<T: JoinMeta> JoinMeta for Join<T> {
 
 #[async_trait]
 pub trait Loadable<DB, T: JoinMeta> {
-    async fn load<'s, 'e, E>(&'s mut self, db: E) -> crate::error::Result<&'s T>
+    async fn load<'s, 'e, E>(&'s mut self, db: E) -> crate::error::CoreResult<&'s T>
     where
         T::IdType: 'e + Send + Sync,
         E: 'e + sqlx::Executor<'e, Database = DB>;
@@ -131,7 +131,7 @@ where
     async fn load<'s, 'e, E: sqlx::Executor<'e, Database = DB> + 'e>(
         &'s mut self,
         conn: E,
-    ) -> crate::error::Result<&'s T>
+    ) -> crate::error::CoreResult<&'s T>
     where
         T::IdType: 'e + Send + Sync,
     {
@@ -228,20 +228,24 @@ impl<T: JoinMeta + Serialize> Serialize for Join<T> {
 }
 
 impl<'de, T> Deserialize<'de> for Join<T>
+where
+    T: JoinMeta + Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        T: JoinMeta + Deserialize<'de>,
+        D: serde::Deserializer<'de>,
     {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: serde::Deserializer<'de>,
-        {
-            let data = Option::<T>::deserialize(deserializer)?;
-            
-            let (id_type, join_data) = match data {
-                Some(value) => (T::_id(&value), JoinData::QueryResult(value)),
-                None => return Err(D::Error::custom("Invalid value"))
-            };
-    
-            Ok(Join { id: id_type, data: join_data })
-        }
+        let data = Option::<T>::deserialize(deserializer)?;
+
+        let (id_type, join_data) = match data {
+            Some(value) => (T::_id(&value), JoinData::QueryResult(value)),
+            None => return Err(D::Error::custom("Invalid value")),
+        };
+
+        Ok(Join {
+            id: id_type,
+            data: join_data,
+        })
     }
+}
+

--- a/core/src/join.rs
+++ b/core/src/join.rs
@@ -31,7 +31,7 @@ impl<T: JoinMeta> JoinMeta for Join<T> {
 
 #[async_trait]
 pub trait Loadable<DB, T: JoinMeta> {
-    async fn load<'s, 'e, E>(&'s mut self, db: E) -> crate::error::CoreResult<&'s T>
+    async fn load<'s, 'e, E>(&'s mut self, db: E) -> crate::error::error::Result<&'s T>
     where
         T::IdType: 'e + Send + Sync,
         E: 'e + sqlx::Executor<'e, Database = DB>;
@@ -131,7 +131,7 @@ where
     async fn load<'s, 'e, E: sqlx::Executor<'e, Database = DB> + 'e>(
         &'s mut self,
         conn: E,
-    ) -> crate::error::CoreResult<&'s T>
+    ) -> crate::error::error::Result<&'s T>
     where
         T::IdType: 'e + Send + Sync,
     {
@@ -248,4 +248,3 @@ where
         })
     }
 }
-

--- a/core/src/join.rs
+++ b/core/src/join.rs
@@ -31,7 +31,7 @@ impl<T: JoinMeta> JoinMeta for Join<T> {
 
 #[async_trait]
 pub trait Loadable<DB, T: JoinMeta> {
-    async fn load<'s, 'e, E>(&'s mut self, db: E) -> crate::error::error::Result<&'s T>
+    async fn load<'s, 'e, E>(&'s mut self, db: E) -> crate::error::Result<&'s T>
     where
         T::IdType: 'e + Send + Sync,
         E: 'e + sqlx::Executor<'e, Database = DB>;
@@ -131,7 +131,7 @@ where
     async fn load<'s, 'e, E: sqlx::Executor<'e, Database = DB> + 'e>(
         &'s mut self,
         conn: E,
-    ) -> crate::error::error::Result<&'s T>
+    ) -> crate::error::Result<&'s T>
     where
         T::IdType: 'e + Send + Sync,
     {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,4 @@
-pub use self::error::{Error, Result};
+pub use self::error::{CoreError, CoreResult};
 pub use self::query_builder::SelectQueryBuilder;
 pub use futures::future::BoxFuture;
 pub use join::Join;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,5 @@
-pub use self::error::{CoreError, CoreResult};
 pub use self::query_builder::SelectQueryBuilder;
+pub use crate::error::{CoreError, CoreResult};
 pub use futures::future::BoxFuture;
 pub use join::Join;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub use self::query_builder::SelectQueryBuilder;
+pub use error::{Error, Result};
 pub use futures::future::BoxFuture;
 pub use join::Join;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,10 +1,9 @@
 pub use self::query_builder::SelectQueryBuilder;
-pub use crate::error::{CoreError, CoreResult};
 pub use futures::future::BoxFuture;
 pub use join::Join;
 
 pub mod config;
-mod error;
+pub mod error;
 pub mod insert;
 pub mod join;
 pub mod model;

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -7,7 +7,7 @@
 ///  - `ormlite::TableMeta`, which you typically don't use directly, but provides table metadata
 ///    (e.g. table name)
 ///
-use crate::error::Result;
+use crate::error;
 use crate::SelectQueryBuilder;
 use futures::future::BoxFuture;
 

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -7,7 +7,7 @@
 ///  - `ormlite::TableMeta`, which you typically don't use directly, but provides table metadata
 ///    (e.g. table name)
 ///
-use crate::CoreResult;
+use crate::error::Result;
 use crate::SelectQueryBuilder;
 use futures::future::BoxFuture;
 
@@ -31,7 +31,7 @@ where
     DB: sqlx::Database,
 {
     type Model;
-    fn insert<'e, A>(self, conn: A) -> BoxFuture<'e, CoreResult<Self::Model>>
+    fn insert<'e, A>(self, conn: A) -> BoxFuture<'e, error::Result<Self::Model>>
     where
         A: 'e + Send + sqlx::Acquire<'e, Database = DB>;
 }
@@ -44,11 +44,11 @@ where
 {
     type Model;
 
-    fn insert<'e: 'a, E>(self, db: E) -> BoxFuture<'a, CoreResult<Self::Model>>
+    fn insert<'e: 'a, E>(self, db: E) -> BoxFuture<'a, error::Result<Self::Model>>
     where
         E: 'e + sqlx::Executor<'e, Database = DB>;
 
-    fn update<'e: 'a, E>(self, db: E) -> BoxFuture<'a, CoreResult<Self::Model>>
+    fn update<'e: 'a, E>(self, db: E) -> BoxFuture<'a, error::Result<Self::Model>>
     where
         E: 'e + sqlx::Executor<'e, Database = DB>;
 
@@ -77,16 +77,16 @@ where
 
     /// `Model` objects can't track what fields are updated, so this method will update all fields.
     /// If you want to update only some fields, use `update_partial` instead.
-    fn update_all_fields<'e, E>(self, db: E) -> BoxFuture<'e, CoreResult<Self>>
+    fn update_all_fields<'e, E>(self, db: E) -> BoxFuture<'e, error::Result<Self>>
     where
         E: 'e + Send + sqlx::Executor<'e, Database = DB>;
 
-    fn delete<'e, E>(self, db: E) -> BoxFuture<'e, CoreResult<()>>
+    fn delete<'e, E>(self, db: E) -> BoxFuture<'e, error::Result<()>>
     where
         E: 'e + sqlx::Executor<'e, Database = DB>;
 
     /// Get by primary key.
-    fn fetch_one<'e, 'a, Arg, E>(id: Arg, db: E) -> BoxFuture<'e, CoreResult<Self>>
+    fn fetch_one<'e, 'a, Arg, E>(id: Arg, db: E) -> BoxFuture<'e, error::Result<Self>>
     where
         'a: 'e,
         E: 'e + sqlx::Executor<'e, Database = DB>,

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -7,7 +7,7 @@
 ///  - `ormlite::TableMeta`, which you typically don't use directly, but provides table metadata
 ///    (e.g. table name)
 ///
-use crate::Result;
+use crate::CoreResult;
 use crate::SelectQueryBuilder;
 use futures::future::BoxFuture;
 
@@ -31,7 +31,7 @@ where
     DB: sqlx::Database,
 {
     type Model;
-    fn insert<'e, A>(self, conn: A) -> BoxFuture<'e, Result<Self::Model>>
+    fn insert<'e, A>(self, conn: A) -> BoxFuture<'e, CoreResult<Self::Model>>
     where
         A: 'e + Send + sqlx::Acquire<'e, Database = DB>;
 }
@@ -44,11 +44,11 @@ where
 {
     type Model;
 
-    fn insert<'e: 'a, E>(self, db: E) -> BoxFuture<'a, Result<Self::Model>>
+    fn insert<'e: 'a, E>(self, db: E) -> BoxFuture<'a, CoreResult<Self::Model>>
     where
         E: 'e + sqlx::Executor<'e, Database = DB>;
 
-    fn update<'e: 'a, E>(self, db: E) -> BoxFuture<'a, Result<Self::Model>>
+    fn update<'e: 'a, E>(self, db: E) -> BoxFuture<'a, CoreResult<Self::Model>>
     where
         E: 'e + sqlx::Executor<'e, Database = DB>;
 
@@ -77,16 +77,16 @@ where
 
     /// `Model` objects can't track what fields are updated, so this method will update all fields.
     /// If you want to update only some fields, use `update_partial` instead.
-    fn update_all_fields<'e, E>(self, db: E) -> BoxFuture<'e, Result<Self>>
+    fn update_all_fields<'e, E>(self, db: E) -> BoxFuture<'e, CoreResult<Self>>
     where
         E: 'e + Send + sqlx::Executor<'e, Database = DB>;
 
-    fn delete<'e, E>(self, db: E) -> BoxFuture<'e, Result<()>>
+    fn delete<'e, E>(self, db: E) -> BoxFuture<'e, CoreResult<()>>
     where
         E: 'e + sqlx::Executor<'e, Database = DB>;
 
     /// Get by primary key.
-    fn fetch_one<'e, 'a, Arg, E>(id: Arg, db: E) -> BoxFuture<'e, Result<Self>>
+    fn fetch_one<'e, 'a, Arg, E>(id: Arg, db: E) -> BoxFuture<'e, CoreResult<Self>>
     where
         'a: 'e,
         E: 'e + sqlx::Executor<'e, Database = DB>,

--- a/core/src/query_builder/select.rs
+++ b/core/src/query_builder/select.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::error::{CoreError, CoreResult};
 use crate::model::Model;
 use crate::query_builder::args::QueryBuilderArgs;
 use crate::query_builder::{util, Placeholder};
@@ -55,7 +55,7 @@ where
     DB: sqlx::Database + DatabaseMetadata,
     DB::Arguments<'args>: IntoArguments<'args, DB>,
 {
-    pub async fn fetch_all<'executor, E>(self, db: E) -> Result<Vec<M>>
+    pub async fn fetch_all<'executor, E>(self, db: E) -> CoreResult<Vec<M>>
     where
         E: Executor<'executor, Database = DB>,
     {
@@ -64,10 +64,10 @@ where
         util::query_as_with_recast_lifetime::<DB, M>(z, args)
             .fetch_all(db)
             .await
-            .map_err(Error::from)
+            .map_err(CoreError::from)
     }
 
-    pub async fn fetch_one<'executor, E>(self, db: E) -> Result<M>
+    pub async fn fetch_one<'executor, E>(self, db: E) -> CoreResult<M>
     where
         E: Executor<'executor, Database = DB>,
     {
@@ -76,10 +76,10 @@ where
         util::query_as_with_recast_lifetime::<DB, M>(z, args)
             .fetch_one(db)
             .await
-            .map_err(Error::from)
+            .map_err(CoreError::from)
     }
 
-    pub async fn fetch_optional<'executor, E>(self, db: E) -> Result<Option<M>>
+    pub async fn fetch_optional<'executor, E>(self, db: E) -> CoreResult<Option<M>>
     where
         E: Executor<'executor, Database = DB>,
     {
@@ -88,7 +88,7 @@ where
         util::query_as_with_recast_lifetime::<DB, M>(z, args)
             .fetch_optional(db)
             .await
-            .map_err(Error::from)
+            .map_err(CoreError::from)
     }
 
     pub fn with(mut self, name: &str, query: &str) -> Self {
@@ -208,12 +208,12 @@ where
         self
     }
 
-    pub fn into_query_and_args(mut self) -> Result<(String, QueryBuilderArgs<'args, DB>)> {
+    pub fn into_query_and_args(mut self) -> CoreResult<(String, QueryBuilderArgs<'args, DB>)> {
         let q = self.query.to_sql(DB::dialect());
         let args = self.arguments;
         let (q, placeholder_count) = util::replace_placeholders(&q, &mut self.gen)?;
         if placeholder_count != args.len() {
-            return Err(Error::OrmliteError(format!(
+            return Err(CoreError::OrmliteError(format!(
                 "Failing to build query. {} placeholders were found in the query, but \
                 {} arguments were provided.",
                 placeholder_count,

--- a/core/src/query_builder/select.rs
+++ b/core/src/query_builder/select.rs
@@ -1,3 +1,4 @@
+use crate::error;
 use crate::model::Model;
 use crate::query_builder::args::QueryBuilderArgs;
 use crate::query_builder::{util, Placeholder};

--- a/core/src/query_builder/util.rs
+++ b/core/src/query_builder/util.rs
@@ -1,5 +1,5 @@
+use crate::error;
 use crate::query_builder::args::QueryBuilderArgs;
-use crate::{CoreError, CoreResult};
 use sqlparser::dialect::GenericDialect;
 use sqlparser::tokenizer::{Token, Tokenizer};
 use sqlx::query::QueryAs;
@@ -7,7 +7,7 @@ use sqlx::query::QueryAs;
 pub fn replace_placeholders<T: Iterator<Item = String>>(
     sql: &str,
     placeholder_generator: &mut T,
-) -> CoreResult<(String, usize)> {
+) -> error::Result<(String, usize)> {
     let mut placeholder_count = 0usize;
     let dialect = GenericDialect {};
     // note this lib is inefficient because it's copying strings everywhere, instead
@@ -33,7 +33,7 @@ pub fn replace_placeholders<T: Iterator<Item = String>>(
                         if let Some(next_tok) = next_tok {
                             match next_tok {
                                 Token::Number(text, _) => {
-                                    let n = text.parse::<usize>().map_err(|_| CoreError::OrmliteError(
+                                    let n = text.parse::<usize>().map_err(|_| error::Error::OrmliteError(
                                     format!("Failed to parse number after a $ during query tokenization. Value was: {text}"
                                     )))?;
                                     buf.push_str(&format!("${next_tok}"));
@@ -72,10 +72,10 @@ where
 mod tests {
     use super::*;
 
-    use crate::CoreResult;
+    use crate::error;
 
     #[test]
-    fn test_replace_placeholders() -> CoreResult<()> {
+    fn test_replace_placeholders() -> error::Result<()> {
         let mut placeholder_generator = vec!["$1", "$2", "$3"].into_iter().map(|s| s.to_string());
         let (sql, placeholder_count) = replace_placeholders(
             "SELECT * FROM users WHERE id = ? OR id = ? OR id = ?",
@@ -87,7 +87,7 @@ mod tests {
     }
 
     #[test]
-    fn test_leave_placeholders_alone() -> CoreResult<()> {
+    fn test_leave_placeholders_alone() -> error::Result<()> {
         let mut placeholder_generator = vec!["$1", "$2", "$3"].into_iter().map(|s| s.to_string());
         let (sql, placeholder_count) =
             replace_placeholders("SELECT * FROM users WHERE email = $1", &mut placeholder_generator)?;

--- a/macro/src/codegen/from_row.rs
+++ b/macro/src/codegen/from_row.rs
@@ -1,8 +1,8 @@
 use crate::codegen::common::{from_row_bounds, OrmliteCodegen};
 use crate::MetadataCache;
-use ormlite_attr::{ColumnMeta, Type};
 use ormlite_attr::Ident;
 use ormlite_attr::TableMeta;
+use ormlite_attr::{ColumnMeta, Type};
 use proc_macro2::TokenStream;
 use quote::quote;
 
@@ -58,7 +58,7 @@ pub fn impl_FromRow(db: &dyn OrmliteCodegen, attr: &TableMeta, cache: &MetadataC
                     )*
                     _ => {
                         return Err(::ormlite::SqlxError::Decode(
-                            Box::new(::ormlite::Error::OrmliteError(format!("Unknown column prefix: {}", prefix))),
+                            Box::new(::ormlite::CoreError::OrmliteError(format!("Unknown column prefix: {}", prefix))),
                         ));
                     }
                 }

--- a/macro/src/codegen/from_row.rs
+++ b/macro/src/codegen/from_row.rs
@@ -58,7 +58,7 @@ pub fn impl_FromRow(db: &dyn OrmliteCodegen, attr: &TableMeta, cache: &MetadataC
                     )*
                     _ => {
                         return Err(::ormlite::SqlxError::Decode(
-                            Box::new(::ormlite::CoreError::OrmliteError(format!("Unknown column prefix: {}", prefix))),
+                            Box::new(::ormlite::error::Error::OrmliteError(format!("Unknown column prefix: {}", prefix))),
                         ));
                     }
                 }

--- a/macro/src/codegen/insert.rs
+++ b/macro/src/codegen/insert.rs
@@ -59,7 +59,7 @@ pub fn impl_Model__insert(db: &dyn OrmliteCodegen, attr: &ModelMeta, metadata_ca
                         let mut stream = q.fetch(&mut *conn);
                         let mut model: Self = ::ormlite::__private::StreamExt::try_next(&mut stream)
                             .await?
-                            .ok_or_else(|| ::ormlite::Error::from(::ormlite::SqlxError::RowNotFound))?;
+                            .ok_or_else(|| ::ormlite::CoreError::from(::ormlite::SqlxError::RowNotFound))?;
                         ::ormlite::__private::StreamExt::try_next(&mut stream).await?;
                         #(
                             #late_bind
@@ -86,7 +86,7 @@ pub fn impl_ModelBuilder__insert(db: &dyn OrmliteCodegen, attr: &TableMeta) -> T
     let bind_parameters = attr.database_columns().map(generate_conditional_bind);
 
     quote! {
-        fn insert<'e: 'a, E>(self, db: E) -> #box_future<'a, ::ormlite::Result<Self::Model>>
+        fn insert<'e: 'a, E>(self, db: E) -> #box_future<'a, ::ormlite::CoreResult<Self::Model>>
         where
             E: 'e +::ormlite::Executor<'e, Database = #db>,
         {
@@ -104,7 +104,7 @@ pub fn impl_ModelBuilder__insert(db: &dyn OrmliteCodegen, attr: &TableMeta) -> T
                 let mut stream = q.fetch(db);
                 let model = ::ormlite::__private::StreamExt::try_next(&mut stream)
                     .await?
-                    .ok_or_else(|| ::ormlite::Error::from(::ormlite::SqlxError::RowNotFound))?;
+                    .ok_or_else(|| ::ormlite::CoreError::from(::ormlite::SqlxError::RowNotFound))?;
                 ::ormlite::__private::StreamExt::try_next(&mut stream).await?;
                 Ok(model)
             })
@@ -162,7 +162,7 @@ pub fn impl_Insert(db: &dyn OrmliteCodegen, meta: &TableMeta, model: &Ident, ret
         impl ::ormlite::model::Insert<#db> for #model {
             type Model = #returns;
 
-            fn insert<'a, A>(self, db: A) -> #box_future<'a, ::ormlite::Result<Self::Model>>
+            fn insert<'a, A>(self, db: A) -> #box_future<'a, ::ormlite::CoreResult<Self::Model>>
             where
                 A: 'a + Send + ::ormlite::Acquire<'a, Database = #db>,
             {
@@ -175,7 +175,7 @@ pub fn impl_Insert(db: &dyn OrmliteCodegen, meta: &TableMeta, model: &Ident, ret
                     let mut stream = q.fetch(&mut *conn);
                     let mut model = ::ormlite::__private::StreamExt::try_next(&mut stream)
                         .await?
-                        .ok_or_else(|| ::ormlite::Error::from(::ormlite::SqlxError::RowNotFound))?;
+                        .ok_or_else(|| ::ormlite::CoreError::from(::ormlite::SqlxError::RowNotFound))?;
                     ::ormlite::__private::StreamExt::try_next(&mut stream).await?;
                     #(#late_bind)*
                     Ok(model)
@@ -217,7 +217,7 @@ pub fn insert_join(c: &ColumnMeta) -> TokenStream {
                     .on_conflict(::ormlite::query_builder::OnConflict::Ignore)
                     .await {
                 Ok(model) => Join::_query_result(model),
-                Err(::ormlite::Error::SqlxError(::ormlite::SqlxError::RowNotFound)) => {
+                Err(::ormlite::CoreError::SqlxError(::ormlite::SqlxError::RowNotFound)) => {
                     let preexisting = #preexisting;
                     Join::_query_result(preexisting)
                 },

--- a/macro/src/codegen/insert.rs
+++ b/macro/src/codegen/insert.rs
@@ -59,7 +59,7 @@ pub fn impl_Model__insert(db: &dyn OrmliteCodegen, attr: &ModelMeta, metadata_ca
                         let mut stream = q.fetch(&mut *conn);
                         let mut model: Self = ::ormlite::__private::StreamExt::try_next(&mut stream)
                             .await?
-                            .ok_or_else(|| ::ormlite::CoreError::from(::ormlite::SqlxError::RowNotFound))?;
+                            .ok_or_else(|| ::ormlite::error::Error::from(::ormlite::SqlxError::RowNotFound))?;
                         ::ormlite::__private::StreamExt::try_next(&mut stream).await?;
                         #(
                             #late_bind
@@ -86,7 +86,7 @@ pub fn impl_ModelBuilder__insert(db: &dyn OrmliteCodegen, attr: &TableMeta) -> T
     let bind_parameters = attr.database_columns().map(generate_conditional_bind);
 
     quote! {
-        fn insert<'e: 'a, E>(self, db: E) -> #box_future<'a, ::ormlite::CoreResult<Self::Model>>
+        fn insert<'e: 'a, E>(self, db: E) -> #box_future<'a, ::ormlite::error::Result<Self::Model>>
         where
             E: 'e +::ormlite::Executor<'e, Database = #db>,
         {
@@ -104,7 +104,7 @@ pub fn impl_ModelBuilder__insert(db: &dyn OrmliteCodegen, attr: &TableMeta) -> T
                 let mut stream = q.fetch(db);
                 let model = ::ormlite::__private::StreamExt::try_next(&mut stream)
                     .await?
-                    .ok_or_else(|| ::ormlite::CoreError::from(::ormlite::SqlxError::RowNotFound))?;
+                    .ok_or_else(|| ::ormlite::error::Error::from(::ormlite::SqlxError::RowNotFound))?;
                 ::ormlite::__private::StreamExt::try_next(&mut stream).await?;
                 Ok(model)
             })
@@ -162,7 +162,7 @@ pub fn impl_Insert(db: &dyn OrmliteCodegen, meta: &TableMeta, model: &Ident, ret
         impl ::ormlite::model::Insert<#db> for #model {
             type Model = #returns;
 
-            fn insert<'a, A>(self, db: A) -> #box_future<'a, ::ormlite::CoreResult<Self::Model>>
+            fn insert<'a, A>(self, db: A) -> #box_future<'a, ::ormlite::error::Result<Self::Model>>
             where
                 A: 'a + Send + ::ormlite::Acquire<'a, Database = #db>,
             {
@@ -175,7 +175,7 @@ pub fn impl_Insert(db: &dyn OrmliteCodegen, meta: &TableMeta, model: &Ident, ret
                     let mut stream = q.fetch(&mut *conn);
                     let mut model = ::ormlite::__private::StreamExt::try_next(&mut stream)
                         .await?
-                        .ok_or_else(|| ::ormlite::CoreError::from(::ormlite::SqlxError::RowNotFound))?;
+                        .ok_or_else(|| ::ormlite::error::Error::from(::ormlite::SqlxError::RowNotFound))?;
                     ::ormlite::__private::StreamExt::try_next(&mut stream).await?;
                     #(#late_bind)*
                     Ok(model)
@@ -217,7 +217,7 @@ pub fn insert_join(c: &ColumnMeta) -> TokenStream {
                     .on_conflict(::ormlite::query_builder::OnConflict::Ignore)
                     .await {
                 Ok(model) => Join::_query_result(model),
-                Err(::ormlite::CoreError::SqlxError(::ormlite::SqlxError::RowNotFound)) => {
+                Err(::ormlite::error::Error::SqlxError(::ormlite::SqlxError::RowNotFound)) => {
                     let preexisting = #preexisting;
                     Join::_query_result(preexisting)
                 },

--- a/macro/src/codegen/model.rs
+++ b/macro/src/codegen/model.rs
@@ -54,7 +54,7 @@ pub fn impl_Model__delete(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> TokenStr
     let db = db.database_ts();
     let id = &attr.pkey.ident;
     quote! {
-        fn delete<'e, E>(self, db: E) -> #box_future<'e, ::ormlite::Result<()>>
+        fn delete<'e, E>(self, db: E) -> #box_future<'e, ::ormlite::CoreResult<()>>
         where
             E: 'e +::ormlite::Executor<'e, Database = #db>
         {
@@ -63,9 +63,9 @@ pub fn impl_Model__delete(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> TokenStr
                     .bind(self.#id)
                     .execute(db)
                     .await
-                    .map_err(::ormlite::Error::from)?;
+                    .map_err(::ormlite::CoreError::from)?;
                 if row.rows_affected() == 0 {
-                    Err(::ormlite::Error::from(::ormlite::SqlxError::RowNotFound))
+                    Err(::ormlite::CoreError::from(::ormlite::SqlxError::RowNotFound))
                 } else {
                     Ok(())
                 }
@@ -87,7 +87,7 @@ pub fn impl_Model__fetch_one(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> Token
     let db = db.database_ts();
     let box_future = crate::util::box_fut_ts();
     quote! {
-        fn fetch_one<'e, 'a, Arg, E>(id: Arg, db: E) -> #box_future<'e, ::ormlite::Result<Self>>
+        fn fetch_one<'e, 'a, Arg, E>(id: Arg, db: E) -> #box_future<'e, ::ormlite::CoreResult<Self>>
         where
             'a: 'e,
             Arg: 'a + Send + ::ormlite::Encode<'a, #db> + ::ormlite::types::Type<#db>,
@@ -98,7 +98,7 @@ pub fn impl_Model__fetch_one(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> Token
                     .bind(id)
                     .fetch_one(db)
                     .await
-                    .map_err(::ormlite::Error::from)
+                    .map_err(::ormlite::CoreError::from)
             })
         }
     }

--- a/macro/src/codegen/model.rs
+++ b/macro/src/codegen/model.rs
@@ -54,7 +54,7 @@ pub fn impl_Model__delete(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> TokenStr
     let db = db.database_ts();
     let id = &attr.pkey.ident;
     quote! {
-        fn delete<'e, E>(self, db: E) -> #box_future<'e, ::ormlite::CoreResult<()>>
+        fn delete<'e, E>(self, db: E) -> #box_future<'e, ::ormlite::error::Result<()>>
         where
             E: 'e +::ormlite::Executor<'e, Database = #db>
         {
@@ -63,9 +63,9 @@ pub fn impl_Model__delete(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> TokenStr
                     .bind(self.#id)
                     .execute(db)
                     .await
-                    .map_err(::ormlite::CoreError::from)?;
+                    .map_err(::ormlite::error::Error::from)?;
                 if row.rows_affected() == 0 {
-                    Err(::ormlite::CoreError::from(::ormlite::SqlxError::RowNotFound))
+                    Err(::ormlite::error::Error::from(::ormlite::SqlxError::RowNotFound))
                 } else {
                     Ok(())
                 }
@@ -87,7 +87,7 @@ pub fn impl_Model__fetch_one(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> Token
     let db = db.database_ts();
     let box_future = crate::util::box_fut_ts();
     quote! {
-        fn fetch_one<'e, 'a, Arg, E>(id: Arg, db: E) -> #box_future<'e, ::ormlite::CoreResult<Self>>
+        fn fetch_one<'e, 'a, Arg, E>(id: Arg, db: E) -> #box_future<'e, ::ormlite::error::Result<Self>>
         where
             'a: 'e,
             Arg: 'a + Send + ::ormlite::Encode<'a, #db> + ::ormlite::types::Type<#db>,
@@ -98,7 +98,7 @@ pub fn impl_Model__fetch_one(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> Token
                     .bind(id)
                     .fetch_one(db)
                     .await
-                    .map_err(::ormlite::CoreError::from)
+                    .map_err(::ormlite::error::Error::from)
             })
         }
     }

--- a/macro/src/codegen/update.rs
+++ b/macro/src/codegen/update.rs
@@ -35,7 +35,7 @@ pub fn impl_Model__update_all_fields(db: &dyn OrmliteCodegen, attr: &ModelMeta) 
     });
 
     quote! {
-        fn update_all_fields<'e, E>(self, db: E) -> #box_future<'e, ::ormlite::CoreResult<Self>>
+        fn update_all_fields<'e, E>(self, db: E) -> #box_future<'e, ::ormlite::error::Result<Self>>
         where
             E: 'e +::ormlite::Executor<'e, Database = #db>,
         {
@@ -47,7 +47,7 @@ pub fn impl_Model__update_all_fields(db: &dyn OrmliteCodegen, attr: &ModelMeta) 
                 q.bind(model.#id)
                     .fetch_one(db)
                     .await
-                    .map_err(::ormlite::CoreError::from)
+                    .map_err(::ormlite::error::Error::from)
             })
         }
     }
@@ -66,7 +66,7 @@ pub fn impl_ModelBuilder__update(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> T
     let bind_update = attr.database_columns().map(generate_conditional_bind);
     let id = &attr.pkey.ident;
     quote! {
-        fn update<'e: 'a, E>(self, db: E) -> #box_future<'a, ::ormlite::CoreResult<Self::Model>>
+        fn update<'e: 'a, E>(self, db: E) -> #box_future<'a, ::ormlite::error::Result<Self::Model>>
         where
             E: 'e +::ormlite::Executor<'e, Database = #db>,
         {
@@ -92,7 +92,7 @@ pub fn impl_ModelBuilder__update(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> T
                 q = q.bind(update_id);
                 q.fetch_one(db)
                     .await
-                    .map_err(::ormlite::CoreError::from)
+                    .map_err(::ormlite::error::Error::from)
             })
         }
     }

--- a/macro/src/codegen/update.rs
+++ b/macro/src/codegen/update.rs
@@ -35,7 +35,7 @@ pub fn impl_Model__update_all_fields(db: &dyn OrmliteCodegen, attr: &ModelMeta) 
     });
 
     quote! {
-        fn update_all_fields<'e, E>(self, db: E) -> #box_future<'e, ::ormlite::Result<Self>>
+        fn update_all_fields<'e, E>(self, db: E) -> #box_future<'e, ::ormlite::CoreResult<Self>>
         where
             E: 'e +::ormlite::Executor<'e, Database = #db>,
         {
@@ -47,7 +47,7 @@ pub fn impl_Model__update_all_fields(db: &dyn OrmliteCodegen, attr: &ModelMeta) 
                 q.bind(model.#id)
                     .fetch_one(db)
                     .await
-                    .map_err(::ormlite::Error::from)
+                    .map_err(::ormlite::CoreError::from)
             })
         }
     }
@@ -66,7 +66,7 @@ pub fn impl_ModelBuilder__update(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> T
     let bind_update = attr.database_columns().map(generate_conditional_bind);
     let id = &attr.pkey.ident;
     quote! {
-        fn update<'e: 'a, E>(self, db: E) -> #box_future<'a, ::ormlite::Result<Self::Model>>
+        fn update<'e: 'a, E>(self, db: E) -> #box_future<'a, ::ormlite::CoreResult<Self::Model>>
         where
             E: 'e +::ormlite::Executor<'e, Database = #db>,
         {
@@ -92,7 +92,7 @@ pub fn impl_ModelBuilder__update(db: &dyn OrmliteCodegen, attr: &ModelMeta) -> T
                 q = q.bind(update_id);
                 q.fetch_one(db)
                     .await
-                    .map_err(::ormlite::Error::from)
+                    .map_err(::ormlite::CoreError::from)
             })
         }
     }

--- a/ormlite/src/lib.rs
+++ b/ormlite/src/lib.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 pub use ::sqlx::{Column, ColumnIndex, Database, Decode, Row};
 pub use model::{FromRow, Insert, IntoArguments, Model, TableMeta};
-pub use ormlite_core::BoxFuture;
-pub use ormlite_core::{CoreError, CoreResult};
+pub use ormlite_core::{error, BoxFuture};
 
 pub use ::sqlx::pool::PoolOptions;
 pub use ::sqlx::{

--- a/ormlite/src/lib.rs
+++ b/ormlite/src/lib.rs
@@ -2,7 +2,7 @@
 pub use ::sqlx::{Column, ColumnIndex, Database, Decode, Row};
 pub use model::{FromRow, Insert, IntoArguments, Model, TableMeta};
 pub use ormlite_core::{
-    error::{Error, Result},
+    error::{self, Error, Result},
     BoxFuture,
 };
 

--- a/ormlite/src/lib.rs
+++ b/ormlite/src/lib.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 pub use ::sqlx::{Column, ColumnIndex, Database, Decode, Row};
 pub use model::{FromRow, Insert, IntoArguments, Model, TableMeta};
-pub use ormlite_core::{error, BoxFuture};
+pub use ormlite_core::{
+    error::{Error, Result},
+    BoxFuture,
+};
 
 pub use ::sqlx::pool::PoolOptions;
 pub use ::sqlx::{

--- a/ormlite/src/lib.rs
+++ b/ormlite/src/lib.rs
@@ -2,7 +2,7 @@
 pub use ::sqlx::{Column, ColumnIndex, Database, Decode, Row};
 pub use model::{FromRow, Insert, IntoArguments, Model, TableMeta};
 pub use ormlite_core::BoxFuture;
-pub use ormlite_core::{Error, Result};
+pub use ormlite_core::{CoreError, CoreResult};
 
 pub use ::sqlx::pool::PoolOptions;
 pub use ::sqlx::{

--- a/ormlite/tests/incomplete_tests/multiple_databases/03-many-to-many.rs
+++ b/ormlite/tests/incomplete_tests/multiple_databases/03-many-to-many.rs
@@ -9,9 +9,7 @@ pub struct Person {
     age: u8,
 }
 
-
-pub static CREATE_TABLE_SQL: &str =
-    "CREATE TABLE person (id text PRIMARY KEY, name TEXT, age INTEGER)";
+pub static CREATE_TABLE_SQL: &str = "CREATE TABLE person (id text PRIMARY KEY, name TEXT, age INTEGER)";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/ormlite/tests/incomplete_tests/multiple_databases/04-one-to-many.rs
+++ b/ormlite/tests/incomplete_tests/multiple_databases/04-one-to-many.rs
@@ -9,9 +9,7 @@ pub struct Person {
     age: u8,
 }
 
-
-pub static CREATE_TABLE_SQL: &str =
-    "CREATE TABLE person (id text PRIMARY KEY, name TEXT, age INTEGER)";
+pub static CREATE_TABLE_SQL: &str = "CREATE TABLE person (id text PRIMARY KEY, name TEXT, age INTEGER)";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/ormlite/tests/incomplete_tests/multiple_databases/main.rs
+++ b/ormlite/tests/incomplete_tests/multiple_databases/main.rs
@@ -15,7 +15,6 @@ pub struct Person {
     age: u8,
 }
 
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -23,21 +22,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let migration = crate::setup::migrate_self(&[file!()]);
     for s in migration.statements {
         let sql = s.to_sql(sqlmo::Dialect::Sqlite);
-        ormlite::query(&sql)
-            .execute(&mut db)
-            .await?;
+        ormlite::query(&sql).execute(&mut db).await?;
     }
 
     let p = Person {
         id: Uuid::new_v4(),
         name: "John".to_string(),
         age: 99,
-    }.insert(&mut db).await?;
+    }
+    .insert(&mut db)
+    .await?;
 
-    let p = p.update_partial()
-        .age(100)
-        .update(&mut db)
-        .await?;
+    let p = p.update_partial().age(100).update(&mut db).await?;
 
     assert_eq!(p.age, 100);
     Ok(())

--- a/ormlite/tests/multifile/main.rs
+++ b/ormlite/tests/multifile/main.rs
@@ -1,28 +1,24 @@
 #[path = "../setup.rs"]
 mod setup;
 
-mod user;
 mod organization;
+mod user;
 
-pub use user::User;
 pub use organization::Organization;
-use uuid::Uuid;
 use ormlite::model::*;
 use ormlite::sqlite::SqliteConnection;
 use ormlite::Connection;
 use sqlmo::ToSql;
+pub use user::User;
+use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = SqliteConnection::connect(":memory:").await?;
-    let migration = setup::migrate_self(&[
-        &std::path::Path::new(file!()).parent().unwrap().display().to_string(),
-    ]);
+    let migration = setup::migrate_self(&[&std::path::Path::new(file!()).parent().unwrap().display().to_string()]);
     for s in migration.statements {
         let sql = s.to_sql(sqlmo::Dialect::Sqlite);
-        ormlite::query(&sql)
-            .execute(&mut conn)
-            .await?;
+        ormlite::query(&sql).execute(&mut conn).await?;
     }
 
     let org_id = Uuid::new_v4();

--- a/ormlite/tests/sqlite/04-allow-clone-primary-key.rs
+++ b/ormlite/tests/sqlite/04-allow-clone-primary-key.rs
@@ -10,28 +10,23 @@ pub struct Person {
     age: u8,
 }
 
-
-pub static CREATE_TABLE_SQL: &str =
-    "CREATE TABLE person (id text PRIMARY KEY, name TEXT, age INTEGER)";
+pub static CREATE_TABLE_SQL: &str = "CREATE TABLE person (id text PRIMARY KEY, name TEXT, age INTEGER)";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let mut db = ormlite::sqlite::SqliteConnection::connect(":memory:").await.unwrap();
-    ormlite::query(CREATE_TABLE_SQL)
-        .execute(&mut db)
-        .await?;
+    ormlite::query(CREATE_TABLE_SQL).execute(&mut db).await?;
 
     let p = Person {
         id: Uuid::new_v4(),
         name: "John".to_string(),
         age: 99,
-    }.insert(&mut db).await?;
+    }
+    .insert(&mut db)
+    .await?;
 
-    let p = p.update_partial()
-        .age(100)
-        .update(&mut db)
-        .await?;
+    let p = p.update_partial().age(100).update(&mut db).await?;
 
     assert_eq!(p.age, 100);
 


### PR DESCRIPTION
When using the `Model` derive macro, user-land `Error` and `Result` conflict with ormlite's `Error` and `Result`.

I renamed them so that consumers of ormlite can have their own `Result` and `Error` in their crate's namespace.