### PR TITLE
remove unnecessary tokio dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ postgres = ["sqlx/postgres"]
 runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls"]
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
 futures.workspace = true
 sqlx.workspace = true
 sqlparser = "0.51.0"
@@ -28,6 +27,7 @@ syn.workspace = true
 serde.workspace = true
 
 [dev-dependencies]
-syn = "2"
 assert_matches = "1"
+syn = "2"
+tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/ormlite/Cargo.toml
+++ b/ormlite/Cargo.toml
@@ -55,12 +55,10 @@ default-mysql = ["mysql", "ormlite-macro/default-mysql"]
 
 [dependencies]
 sqlx = { version = "0.8.2" }
-tokio = { version = "1.40.0", features = ["full"] }
 ormlite-macro.workspace = true
 ormlite-core.workspace = true
 sqlx-core.workspace = true
 sqlmo.workspace = true
-tokio-stream = "0.1.16"
 
 [dev-dependencies]
 trybuild = { version = "1.0.99", features = ["diff"] }
@@ -69,3 +67,4 @@ uuid = { version = "1.10.0", features = ["serde", "v4"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = { version = "1.0.128" }
 chrono = { version = "0.4.38", features = ["serde"] }
+tokio = { version = "1.45.1", features = ["full"] }

--- a/ormlite/src/lib.rs
+++ b/ormlite/src/lib.rs
@@ -4,7 +4,6 @@ pub use ormlite_core::BoxFuture;
 pub use ormlite_core::{Error, Result};
 pub use ormlite_macro::Enum;
 pub use sqlx::{Column, ColumnIndex, Database, Decode, Row};
-pub use tokio_stream::StreamExt;
 
 pub use sqlx::pool::PoolOptions;
 pub use sqlx::{


### PR DESCRIPTION
Apparently, the crate depended on tokio, but only used it for testing. Users should be unaffected.